### PR TITLE
Fix 500 on accepting user task and some other stuffs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - master
       - develop
 jobs:
   test:
@@ -45,7 +44,6 @@ jobs:
         registry: docker.pkg.github.com
   deploy-staging:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop'
     needs: build
     steps:
     - name: Run deployment script over SSH
@@ -56,16 +54,3 @@ jobs:
         USER: ${{ secrets.USER }}
       with:
         args: "/root/deployment-scripts/deploy-staging.sh"
-  deploy-prod:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    needs: build
-    steps:
-    - name: Run deployment script over SSH
-      uses: maddox/actions/ssh@master
-      env:
-        PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        HOST: ${{ secrets.HOST }}
-        USER: ${{ secrets.USER }}
-      with:
-        args: "/root/deployment-scripts/deploy-production.sh"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
     needs: test
     steps:
     - uses: actions/checkout@master
+      with:
+        ref: develop
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy to Production
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy-prod:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Run deployment script over SSH
+      uses: maddox/actions/ssh@master
+      env:
+        PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        HOST: ${{ secrets.HOST }}
+        USER: ${{ secrets.USER }}
+      with:
+        args: "/root/deployment-scripts/deploy-production.sh"

--- a/arkav/announcement/tests/test_services.py
+++ b/arkav/announcement/tests/test_services.py
@@ -1,4 +1,6 @@
 from arkav.arkavauth.models import User
+from arkav.announcement.models import Announcement
+from arkav.announcement.models import AnnouncementUser
 from arkav.announcement.services import AnnouncementService
 from django.test import TestCase
 
@@ -14,6 +16,7 @@ class AnnouncementServiceTestCase(TestCase):
                                                 users=User.objects.filter(email='yonas@gmail.com'))
         AnnouncementService().send_announcement(title='A3', message='announcement3',
                                                 users=User.objects.filter(email='jones@gmail.com'))
+        AnnouncementService().send_announcement(title='A4', message='announcement3', users=[])
 
         self.assertIsNotNone(self.user1.announcements.filter(title='A1').first())
         self.assertIsNotNone(self.user1.announcements.filter(title='A2').first())
@@ -22,3 +25,6 @@ class AnnouncementServiceTestCase(TestCase):
         self.assertIsNotNone(self.user2.announcements.filter(title='A1').first())
         self.assertIsNone(self.user2.announcements.filter(title='A2').first())
         self.assertIsNotNone(self.user2.announcements.filter(title='A3').first())
+
+        self.assertEqual(Announcement.objects.filter(title='A4').count(), 1)
+        self.assertEqual(AnnouncementUser.objects.filter(announcement__title='A4').count(), 0)

--- a/arkav/competition/admin.py
+++ b/arkav/competition/admin.py
@@ -134,7 +134,7 @@ class AbstractTaskResponseAdmin(admin.ModelAdmin):
                 form.save(task_response, request.user)
                 self.message_user(request, 'Success')
                 url = reverse(
-                    'admin:competition_taskresponse_changelist',
+                    'admin:competition_{}_changelist'.format(self.model._meta.model_name),
                     current_app=self.admin_site.name,
                 )
                 return HttpResponseRedirect(url)

--- a/arkav/competition/services.py
+++ b/arkav/competition/services.py
@@ -246,15 +246,17 @@ class TaskResponseService:
         task_response.status = TaskResponse.COMPLETED
         task_response.save()
 
+        users = []
         if task_response.task.is_user_task:
-            users = [task_response.team_member.user]
+            if task_response.team_member.user is not None:
+                users = [task_response.team_member.user]
         else:
             users = task_response.team.members.all()
         AnnouncementService().send_announcement(
             title="{} Task Completion".format(task_response.task),
             message="Submisi berkas Anda untuk {} sudah diverifikasi dan diterima".format(
                 task_response.task),
-            users=users
+            users=users,
         )
 
     @transaction.atomic
@@ -263,13 +265,15 @@ class TaskResponseService:
         task_response.status = TaskResponse.REJECTED
         task_response.save()
 
+        users = []
         if task_response.task.is_user_task:
-            users = [task_response.team_member.user]
+            if task_response.team_member.user is not None:
+                users = [task_response.team_member.user]
         else:
             users = task_response.team.members.all()
         AnnouncementService().send_announcement(
             title="{} Task Rejection".format(task_response.task),
             message="Submisi berkas Anda untuk {} ditolak, lihat alasannya pada tab Competition!".format(
                 task_response.task),
-            users=users
+            users=users,
         )

--- a/arkav/competition/tests/test_services.py
+++ b/arkav/competition/tests/test_services.py
@@ -27,6 +27,7 @@ class TaskResponseServiceTestCase(TestCase):
 
         self.team_member1 = TeamMember.objects.create(team=self.ctf_team, user=self.user1)
         self.team_member2 = TeamMember.objects.create(team=self.ctf_team, user=self.user2)
+        self.team_member3 = TeamMember.objects.create(team=self.ctf_team, user=None)
 
         self.category_documents = TaskCategory.objects.create(name='Documents')
         self.widget_file = TaskWidget.objects.create(name='File')
@@ -88,6 +89,19 @@ class TaskResponseServiceTestCase(TestCase):
         self.assertEqual(AnnouncementUser.objects.count(), 1)
         self.assertEqual(AnnouncementUser.objects.first().user, self.user1)
         self.assertEqual('{} Task Completion'.format(ctf_user_task_response.task), Announcement.objects.first().title)
+
+    def test_accept_user_task_response_unregistered_user(self):
+        ctf_user_task_response = UserTaskResponse(
+            team_member=self.team_member3,
+            task=self.ctf_user_task,
+            team=self.ctf_team,
+            response=self.ctf_team_task.name,
+            status=AbstractTaskResponse.AWAITING_VALIDATION,
+        )
+        TaskResponseService().accept_task_response(ctf_user_task_response)
+        ctf_user_task_response.refresh_from_db()
+        self.assertEqual(ctf_user_task_response.status, AbstractTaskResponse.COMPLETED)
+        self.assertEqual(AnnouncementUser.objects.count(), 0)
 
     def test_reject_user_task_response(self):
         ctf_user_task_response = UserTaskResponse(

--- a/arkav/competition/tests/views/test_submit_task.py
+++ b/arkav/competition/tests/views/test_submit_task.py
@@ -145,7 +145,7 @@ class SubmitUserTaskTestCase(APITestCase):
 
         user_task_response = UserTaskResponse.objects.first()
         self.assertEqual(user_task_response.response, data['response'])
-        self.assertEqual(user_task_response.team_member.id, self.user2.id)
+        self.assertEqual(user_task_response.team_member.user.id, self.user2.id)
 
     def test_submit_user_task_not_team_member(self):
         '''

--- a/arkav/competition/tests/views/test_team_detail.py
+++ b/arkav/competition/tests/views/test_team_detail.py
@@ -92,7 +92,7 @@ class TeamDetailTestCase(APITestCase):
         self.assertEqual(res.data['stages'][0]['tasks'][0]['widget_parameters']['original'], 'Halo, {{ team.name }}!')
         self.assertEqual(res.data['stages'][0]['tasks'][1]['widget_parameters']['description'], 'Tanpa template')
         self.assertEqual(res.data['stages'][0]['tasks'][1]['widget_parameters']['original'], 'Tanpa template')
-        self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['description'], str(100 + self.team.id))  # 100 + team id
+        self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['description'], str(100 + self.team.id))
         self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['original'], '{{ team_number }}')
 
         self.assertIn('task_responses', res.data)

--- a/arkav/competition/tests/views/test_team_detail.py
+++ b/arkav/competition/tests/views/test_team_detail.py
@@ -92,7 +92,7 @@ class TeamDetailTestCase(APITestCase):
         self.assertEqual(res.data['stages'][0]['tasks'][0]['widget_parameters']['original'], 'Halo, {{ team.name }}!')
         self.assertEqual(res.data['stages'][0]['tasks'][1]['widget_parameters']['description'], 'Tanpa template')
         self.assertEqual(res.data['stages'][0]['tasks'][1]['widget_parameters']['original'], 'Tanpa template')
-        self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['description'], '101')  # 100 + team id
+        self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['description'], str(100 + self.team.id))  # 100 + team id
         self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['original'], '{{ team_number }}')
 
         self.assertIn('task_responses', res.data)
@@ -102,5 +102,7 @@ class TeamDetailTestCase(APITestCase):
         self.assertEqual(res.data['task_responses'][0]['task_id'], self.task1.id)
         self.assertEqual(res.data['user_task_responses'][0]['task_id'], self.task2.id)
         self.assertEqual(res.data['user_task_responses'][1]['task_id'], self.task2.id)
-        self.assertEqual(res.data['user_task_responses'][0]['user_id'], self.user1.id)
-        self.assertEqual(res.data['user_task_responses'][1]['user_id'], self.user2.id)
+        self.assertEqual(res.data['user_task_responses'][0]['team_member_id'],
+                         self.team.team_members.filter(user=self.user1).first().id)
+        self.assertEqual(res.data['user_task_responses'][1]['team_member_id'],
+                         self.team.team_members.filter(user=self.user2).first().id)

--- a/arkav/mainevent/tests/views/test_registrant_detail.py
+++ b/arkav/mainevent/tests/views/test_registrant_detail.py
@@ -76,7 +76,7 @@ class RegistrantDetailTestCase(APITestCase):
         self.assertEqual(res.data['stages'][0]['tasks'][1]['widget_parameters']['description'], 'Tanpa template')
         self.assertEqual(res.data['stages'][0]['tasks'][1]['widget_parameters']['original'], 'Tanpa template')
         self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['description'],
-                         '601')  # 600 + registrant id
+                         str(600 + self.registrant.id))  # 600 + registrant id
         self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['original'], '{{ registrant_number }}')
 
         self.assertIn('task_responses', res.data)

--- a/arkav/preevent/tests/views/test_registrant_detail.py
+++ b/arkav/preevent/tests/views/test_registrant_detail.py
@@ -73,7 +73,8 @@ class RegistrantListTestCase(APITestCase):
                          'Halo, {{ registrant.user.email }}!')
         self.assertEqual(res.data['stages'][0]['tasks'][1]['widget_parameters']['description'], 'Tanpa template')
         self.assertEqual(res.data['stages'][0]['tasks'][1]['widget_parameters']['original'], 'Tanpa template')
-        self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['description'], '101')
+        self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['description'],
+                         str(100 + self.registrant.id))
         self.assertEqual(res.data['stages'][0]['tasks'][2]['widget_parameters']['original'], '{{ registrant_number }}')
 
         self.assertIn('task_responses', res.data)


### PR DESCRIPTION
- Fix 500 on accepting user task
- Add more test and fix some tests so it will pass on postgre too
- Only test & build on develop, not master so the master will be faster
- Checkout to develop instead of master
- Redirect to correct page after task response accept / reject